### PR TITLE
fix eslint work on vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.format.enable": false,
   "editor.formatOnSave": true,
+  "eslint.packageManager": "pnpm",
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   },
   "devDependencies": {
     "dotenv-cli": "^7.2.1",
+    "eslint": "^8.42.0",
+    "eslint-config-custom": "*",
     "git-cz": "^4.9.0",
     "prettier": "^2.8.2",
     "turbo": "1.10.3"
   },
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=18.16.0"
   },
   "packageManager": "pnpm@8.6.1"
 }

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -3,6 +3,7 @@ module.exports = {
   extends: ["next/core-web-vitals", "turbo", "prettier", "plugin:storybook/recommended"],
   plugins: ["import", "unused-imports"],
   rules: {
+    "@next/next/no-html-link-for-pages": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "unused-imports/no-unused-imports": "warn",
     "import/order": [

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -11,7 +11,8 @@
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-storybook": "^0.6.12",
-    "eslint-plugin-unused-imports": "^2.0.0"
+    "eslint-plugin-unused-imports": "^2.0.0",
+    "next": "^13.4.4"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^8.42.0
         version: 8.42.0
       eslint-config-custom:
-        specifier: workspace:*
+        specifier: '*'
         version: link:packages/eslint-config-custom
       git-cz:
         specifier: ^4.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       dotenv-cli:
         specifier: ^7.2.1
         version: 7.2.1
+      eslint:
+        specifier: ^8.42.0
+        version: 8.42.0
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:packages/eslint-config-custom
       git-cz:
         specifier: ^4.9.0
         version: 4.9.0
@@ -232,6 +238,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^2.0.0
         version: 2.0.0(eslint@8.42.0)
+      next:
+        specifier: ^13.4.4
+        version: 13.4.4(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0)
 
   packages/tsconfig: {}
 


### PR DESCRIPTION
add packageManager info to eslint extension of vscode, add eslint and
config-custom to root, add next to eslint-custom-config because eslint
cannot find next/babel module in this package
